### PR TITLE
Add link to public PRs in the discussion footer

### DIFF
--- a/web-app/src/eventHandlers/pullRequestEventHandler.ts
+++ b/web-app/src/eventHandlers/pullRequestEventHandler.ts
@@ -209,8 +209,7 @@ export class PullRequestEventHandler {
     // Get pull request comments
     const app = await appGitHubService.getAuthenticatedApp();
     const appLogin = `${app.slug}[bot]`;
-    const pullRequestLink = payload.pull_request.html_url;
-    const optionalPullRequestFooterMarkdown = payload.repository.private ? "" : `<a href='${pullRequestLink}'>from a pull request</a> `;
+    const optionalPullRequestFooterMarkdown = payload.repository.private ? "" : `<a href='${payload.pull_request.html_url}'>from a pull request</a> `;
     const postFooter = `\n\n<hr /><em>This discussion was created ${optionalPullRequestFooterMarkdown}using <a href='${app.html_url}'>${app.name}</a>.</em>\n`;
 
     const pullRequestComments = await appGitHubService.getPullRequestComments({

--- a/web-app/src/eventHandlers/pullRequestEventHandler.ts
+++ b/web-app/src/eventHandlers/pullRequestEventHandler.ts
@@ -209,7 +209,9 @@ export class PullRequestEventHandler {
     // Get pull request comments
     const app = await appGitHubService.getAuthenticatedApp();
     const appLogin = `${app.slug}[bot]`;
-    const postFooter = `\n\n<hr /><em>This discussion was created using <a href='${app.html_url}'>${app.name}</a>.</em>\n`;
+    const pullRequestLink = payload.pull_request.html_url;
+    const optionalPullRequestFooterMarkdown = payload.repository.private ? "" : `from a <a href='${pullRequestLink}'>pull request</a> `;
+    const postFooter = `\n\n<hr /><em>This discussion was created ${optionalPullRequestFooterMarkdown}using <a href='${app.html_url}'>${app.name}</a>.</em>\n`;
 
     const pullRequestComments = await appGitHubService.getPullRequestComments({
       ...pullInfo,

--- a/web-app/src/eventHandlers/pullRequestEventHandler.ts
+++ b/web-app/src/eventHandlers/pullRequestEventHandler.ts
@@ -210,7 +210,7 @@ export class PullRequestEventHandler {
     const app = await appGitHubService.getAuthenticatedApp();
     const appLogin = `${app.slug}[bot]`;
     const pullRequestLink = payload.pull_request.html_url;
-    const optionalPullRequestFooterMarkdown = payload.repository.private ? "" : `from a <a href='${pullRequestLink}'>pull request</a> `;
+    const optionalPullRequestFooterMarkdown = payload.repository.private ? "" : `<a href='${pullRequestLink}'>from a pull request</a> `;
     const postFooter = `\n\n<hr /><em>This discussion was created ${optionalPullRequestFooterMarkdown}using <a href='${app.html_url}'>${app.name}</a>.</em>\n`;
 
     const pullRequestComments = await appGitHubService.getPullRequestComments({


### PR DESCRIPTION
This adds links back to the pull request from the discussion footer when the PR was in a public repo.

Test: https://github.com/philip-gai/announcement-drafter-tests/pull/16

Related to https://github.com/philip-gai/announcement-drafter/issues/78