### PR TITLE
feat: Support discussion labels

### DIFF
--- a/.github/workflows/composite/azure-subscription-deployment/action.yml
+++ b/.github/workflows/composite/azure-subscription-deployment/action.yml
@@ -110,8 +110,11 @@ runs:
             
             Write-Host $formattedOutput
           } else {
-            $result = $(New-AzSubscriptionDeployment @params | ConvertTo-Json)
-            "deployment=$result" | Out-File -FilePath $env:GITHUB_OUTPUT -Append
+            $result = $(New-AzSubscriptionDeployment @params | ConvertTo-Json -Compress -Depth 10)
+            # Use delimiter syntax for multi-line output
+            "deployment<<EOF" | Out-File -FilePath $env:GITHUB_OUTPUT -Append
+            $result | Out-File -FilePath $env:GITHUB_OUTPUT -Append -NoNewline
+            "EOF" | Out-File -FilePath $env:GITHUB_OUTPUT -Append
           }
         azPSVersion: "latest"
         failOnStandardError: "false"

--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ A note on org discussions: Org discussions are backed by repository discussions,
 <!--
 repo: https://github.com/philip-gai/announcement-drafter-demo
 category: announcements
+labels: enhancement, documentation
 -->
 
 <!-- This is the discussion title -->
@@ -81,6 +82,7 @@ Demo repo: [announcement-drafter demo]
 | `repository` or `repo`     | The full url to the repository to create the discussion in<br/>**Prerequisites:**<br/>&nbsp;&nbsp;1. Discussions are enabled<br/>&nbsp;&nbsp;2. The app is installed on the repo | **Conditional**: Required if no `team` is provided       | `https://github.com/philip-gai/announcement-drafter-demo` |
 | `team`           | The full url to the team to create the discussion in<br/>**Prerequisites:**<br/>&nbsp;&nbsp;1. The app is installed on the team organization                                     | **Conditional**: Required if no `repository` is provided | `https://github.com/orgs/elastico-group/teams/everyone`   |
 | `category`       | The name of the discussion category                                                                                                                                              | **Conditional**: Required if `repository` is provided    | `announcements`                                           |
+| `labels`         | Labels to add to the discussion. Can be comma-separated or YAML list format<br/>**Note:** Labels must already exist in the target repository                                      | No                                                       | `enhancement, documentation` or YAML list                 |
 | Discussion Title | The title of your discussion should be the first top-level header (i.e. `# Discussion Title`)                                                                                    | Yes                                                      | See [Example](#draft-an-org-or-repository-discussion)                                  |
 | Discussion Body  | The body of your discussion is everything after the top-level header                                                                                                             | Yes                                                      | See [Example](#draft-an-org-or-repository-discussion)                                  |
 

--- a/scripts/e2e-test.sh
+++ b/scripts/e2e-test.sh
@@ -3,26 +3,37 @@
 # E2E Test Script for Announcement Drafter
 #
 # This script automates end-to-end testing by:
-# 1. Starting the dev server
-# 2. Creating a test PR in the test repository
-# 3. Verifying the bot comments on the PR
-# 4. Cleaning up the test PR
+# 1. Checking for valid OAuth token in CosmosDB
+# 2. Starting the dev server
+# 3. Creating a test PR in the test repository
+# 4. Verifying the bot comments on the PR
+# 5. Optionally merging and verifying discussion creation with labels
 #
-# Usage: ./scripts/e2e-test.sh [--no-cleanup]
+# Usage: ./scripts/e2e-test.sh [--no-cleanup] [--merge] [--skip-auth-check]
 #
 # Options:
-#   --no-cleanup    Keep the test PR open after testing (for manual inspection)
+#   --no-cleanup      Keep the test PR open after testing (for manual inspection)
+#   --merge           Merge the PR and verify discussion creation (requires admin rights)
+#   --skip-auth-check Skip the OAuth token check
+#
+# Prerequisites:
+# - User must be authenticated with the dev app (visit http://localhost:3000/login/oauth/authorize)
+# - The test markdown file must use HTML comment format (<!-- ... -->) not YAML front matter
 #
 
 set -e
 
 # Configuration
 TEST_REPO="philip-gai/announcement-drafter-tests"
-WEB_APP_DIR="$(dirname "$0")/../web-app"
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+WEB_APP_DIR="$SCRIPT_DIR/../web-app"
 CLEANUP=true
+MERGE_PR=false
+SKIP_AUTH_CHECK=false
 SERVER_PID=""
 BRANCH_NAME=""
 PR_NUMBER=""
+DISCUSSION_URL=""
 
 # Colors for output
 RED='\033[0;31m'
@@ -35,6 +46,14 @@ for arg in "$@"; do
     case $arg in
         --no-cleanup)
             CLEANUP=false
+            shift
+            ;;
+        --merge)
+            MERGE_PR=true
+            shift
+            ;;
+        --skip-auth-check)
+            SKIP_AUTH_CHECK=true
             shift
             ;;
     esac
@@ -51,11 +70,14 @@ cleanup() {
         wait "$SERVER_PID" 2>/dev/null || true
     fi
     
-    # Close the PR and delete the branch if cleanup is enabled
-    if [ "$CLEANUP" = true ] && [ -n "$PR_NUMBER" ]; then
+    # Also kill any process on port 3000
+    lsof -ti :3000 | xargs -r kill -9 2>/dev/null || true
+    
+    # Close the PR and delete the branch if cleanup is enabled and PR wasn't merged
+    if [ "$CLEANUP" = true ] && [ -n "$PR_NUMBER" ] && [ -z "$DISCUSSION_URL" ]; then
         echo "Closing PR #$PR_NUMBER and deleting branch..."
         gh pr close "$PR_NUMBER" --repo "$TEST_REPO" --delete-branch 2>/dev/null || true
-    elif [ -n "$PR_NUMBER" ]; then
+    elif [ -n "$PR_NUMBER" ] && [ -z "$DISCUSSION_URL" ]; then
         echo -e "${YELLOW}PR #$PR_NUMBER left open for manual inspection${NC}"
         echo "View at: https://github.com/$TEST_REPO/pull/$PR_NUMBER"
     fi
@@ -74,9 +96,64 @@ echo -e "${GREEN}  Announcement Drafter E2E Test${NC}"
 echo -e "${GREEN}========================================${NC}"
 echo ""
 
+# Step 0: Check OAuth token (required for merge flow)
+if [ "$MERGE_PR" = true ] && [ "$SKIP_AUTH_CHECK" = false ]; then
+    echo -e "${YELLOW}Step 0: Checking OAuth token...${NC}"
+    cd "$WEB_APP_DIR"
+    
+    # Get the current user's login
+    USER_LOGIN=$(gh api user --jq '.login' 2>/dev/null || echo "")
+    if [ -z "$USER_LOGIN" ]; then
+        echo -e "${RED}Error: Could not determine GitHub user login${NC}"
+        exit 1
+    fi
+    
+    # Check if token exists in CosmosDB
+    TOKEN_CHECK=$(node -e "
+require('dotenv').config();
+const { CosmosClient } = require('@azure/cosmos');
+const client = new CosmosClient({ endpoint: process.env.COSMOS_URI, key: process.env.COSMOS_PRIMARY_KEY });
+client.database('AnnouncementDrafter').container('Tokens').item('$USER_LOGIN', '$USER_LOGIN').read()
+  .then(r => {
+    if (r.resource) {
+      const expired = Date.now() > Date.parse(r.resource.refreshTokenExpiresAt);
+      console.log(expired ? 'expired' : 'valid');
+    } else {
+      console.log('missing');
+    }
+  })
+  .catch(() => console.log('error'));
+" 2>/dev/null)
+    
+    if [ "$TOKEN_CHECK" = "valid" ]; then
+        echo -e "${GREEN}✅ OAuth token found for $USER_LOGIN${NC}"
+    elif [ "$TOKEN_CHECK" = "expired" ]; then
+        echo -e "${RED}❌ OAuth token for $USER_LOGIN is expired${NC}"
+        echo ""
+        echo "Please re-authenticate by visiting:"
+        echo "  http://localhost:3000/login/oauth/authorize"
+        echo ""
+        echo "Then run this script again."
+        exit 1
+    else
+        echo -e "${YELLOW}⚠️  No OAuth token found for $USER_LOGIN${NC}"
+        echo ""
+        echo "For the --merge flow to work, you need to authenticate first."
+        echo "Please visit: http://localhost:3000/login/oauth/authorize"
+        echo ""
+        echo "Then run this script again, or use --skip-auth-check to skip this check."
+        exit 1
+    fi
+    echo ""
+fi
+
 # Step 1: Build and start the dev server
 echo -e "${YELLOW}Step 1: Starting dev server...${NC}"
 cd "$WEB_APP_DIR"
+
+# Kill any existing process on port 3000
+lsof -ti :3000 | xargs -r kill -9 2>/dev/null || true
+sleep 1
 
 # Build first
 echo "Building TypeScript..."
@@ -116,26 +193,28 @@ git pull --quiet
 BRANCH_NAME="e2e-test-$(date +%s)"
 git checkout -b "$BRANCH_NAME"
 
-# Step 3: Create test announcement file
+# Step 3: Create test announcement file from fixtures
+# IMPORTANT: The file must use HTML comment format (<!-- ... -->) for YAML header,
+# NOT YAML front matter (--- ... ---). The parser looks for <!-- and --> delimiters.
 echo ""
-echo -e "${YELLOW}Step 3: Creating test announcement file...${NC}"
+echo -e "${YELLOW}Step 3: Creating test announcement file from fixtures...${NC}"
 mkdir -p tests
-cat > tests/e2e-test-announcement.md << 'EOF'
-<!--
-author: philip-gai
-repository: https://github.com/philip-gai/announcement-drafter-tests
-category: announcements
--->
 
-# E2E Test Announcement
-
-This is an automated test announcement created by the e2e-test.sh script.
-
-Testing timestamp: TIMESTAMP_PLACEHOLDER
-EOF
-
-# Replace timestamp placeholder
-sed -i "s/TIMESTAMP_PLACEHOLDER/$(date -u '+%Y-%m-%d %H:%M:%S UTC')/" tests/e2e-test-announcement.md
+# Copy fixture and modify for test repo
+FIXTURE_FILE="$SCRIPT_DIR/../web-app/test/fixtures/discussion_posts/with-labels.md"
+if [ -f "$FIXTURE_FILE" ]; then
+    # Copy fixture and update repository URL and category for test repo
+    sed -e 's|repository: https://github.com/philip-gai/announcement-drafter|repo: https://github.com/philip-gai/announcement-drafter-tests|' \
+        -e 's|category: announcements|category: Announcements|' \
+        "$FIXTURE_FILE" > tests/e2e-test-announcement.md
+    
+    # Append timestamp to make each test unique
+    echo "" >> tests/e2e-test-announcement.md
+    echo "Test run: $(date -u '+%Y-%m-%d %H:%M:%S UTC')" >> tests/e2e-test-announcement.md
+else
+    echo -e "${RED}Fixture file not found: $FIXTURE_FILE${NC}"
+    exit 1
+fi
 
 git add .
 git commit -m "Add e2e test announcement" --quiet
@@ -192,7 +271,14 @@ if [ "$BOT_COMMENTED" = true ]; then
     echo "---"
     echo "$BOT_COMMENT" | head -10
     echo "---"
-    EXIT_CODE=0
+    
+    # Check if it's an error comment
+    if echo "$BOT_COMMENT" | grep -q "⛔️"; then
+        echo -e "${RED}⚠️  Bot comment indicates an error${NC}"
+        EXIT_CODE=1
+    else
+        EXIT_CODE=0
+    fi
 else
     echo -e "${RED}❌ FAILURE: Bot did not comment within $((MAX_RETRIES * RETRY_INTERVAL)) seconds${NC}"
     echo ""
@@ -202,7 +288,57 @@ else
     EXIT_CODE=1
 fi
 
+# Step 7: Optionally merge and verify discussion creation
+if [ "$MERGE_PR" = true ] && [ "$EXIT_CODE" -eq 0 ]; then
+    echo ""
+    echo -e "${YELLOW}Step 7: Merging PR and verifying discussion creation...${NC}"
+    
+    # Merge the PR (requires admin rights due to branch protection)
+    echo "Merging PR #$PR_NUMBER..."
+    if gh pr merge "$PR_NUMBER" --repo "$TEST_REPO" --squash --delete-branch --admin 2>/dev/null; then
+        echo -e "${GREEN}PR merged successfully${NC}"
+        
+        # Wait for webhook to process and discussion to be created
+        echo "Waiting for discussion to be created..."
+        sleep 10
+        
+        # Check for success reply comment on the PR
+        SUCCESS_COMMENT=$(gh api "/repos/$TEST_REPO/pulls/$PR_NUMBER/comments" 2>/dev/null | \
+            jq -r '.[] | select(.body | contains("🎉")) | .body' 2>/dev/null | head -1 || echo "")
+        
+        if [ -n "$SUCCESS_COMMENT" ]; then
+            # Extract discussion URL from the comment
+            DISCUSSION_URL=$(echo "$SUCCESS_COMMENT" | grep -oE 'https://github.com/[^)]+/discussions/[0-9]+' | head -1 || echo "")
+            
+            if [ -n "$DISCUSSION_URL" ]; then
+                echo -e "${GREEN}✅ Discussion created: $DISCUSSION_URL${NC}"
+                
+                # Verify labels were applied (this may fail due to API permissions)
+                DISCUSSION_NUM=$(echo "$DISCUSSION_URL" | grep -oE '[0-9]+$')
+                echo ""
+                echo "Note: To verify labels, check the discussion manually:"
+                echo "  $DISCUSSION_URL"
+                echo ""
+                echo "Expected labels: enhancement, documentation"
+            else
+                echo -e "${YELLOW}⚠️  Could not extract discussion URL from success comment${NC}"
+            fi
+        else
+            echo -e "${RED}❌ No success comment found - discussion may not have been created${NC}"
+            echo ""
+            echo "Check the server logs for errors."
+            EXIT_CODE=1
+        fi
+    else
+        echo -e "${RED}❌ Failed to merge PR (may need --admin flag or admin rights)${NC}"
+        EXIT_CODE=1
+    fi
+fi
+
 echo ""
 echo "PR: https://github.com/$TEST_REPO/pull/$PR_NUMBER"
+if [ -n "$DISCUSSION_URL" ]; then
+    echo "Discussion: $DISCUSSION_URL"
+fi
 
 exit $EXIT_CODE

--- a/web-app/package.json
+++ b/web-app/package.json
@@ -14,6 +14,7 @@
   "scripts": {
     "build:dev": "tsc",
     "start": "probot run ./lib/index.js",
+    "start:bg": "lsof -ti :3000 | xargs -r kill -9 2>/dev/null; sleep 1; probot run ./lib/index.js &",
     "dev": "npm run build:dev && npm run start",
     "lint": "eslint '*/**/*.{js,ts,tsx}' --quiet --fix"
   },

--- a/web-app/src/services/parserService.ts
+++ b/web-app/src/services/parserService.ts
@@ -7,6 +7,7 @@ export interface ParsedMarkdownDiscussion {
   team: string | undefined;
   teamOwner: string | undefined;
   discussionCategoryName: string | undefined;
+  labels: string[];
   postBody: string;
   postTitle: string;
   headerEndLine: number;
@@ -96,6 +97,22 @@ export class ParserService {
     return categoryName;
   }
 
+  public getLabels(): string[] {
+    const rawLabels = this.getYamlHeader().labels;
+    if (!rawLabels) return [];
+    // Support both array format (YAML list) and comma-separated string
+    if (Array.isArray(rawLabels)) {
+      return rawLabels.map((label) => String(label).trim()).filter((label) => label.length > 0);
+    }
+    if (typeof rawLabels === "string") {
+      return rawLabels
+        .split(",")
+        .map((label) => label.trim())
+        .filter((label) => label.length > 0);
+    }
+    return [];
+  }
+
   public getPostTitle(): string {
     if (!this._content.includes("# ")) throw new Error("You must include a top level header # in your markdown that has the post title");
     const postTitle = this._content.split("# ")[1].split("\n")[0].trim();
@@ -127,6 +144,7 @@ export class ParserService {
       team: this.getTargetTeamName(),
       teamOwner: this.getTargetTeamOwner(),
       discussionCategoryName: this.getDiscussionCategoryName(),
+      labels: this.getLabels(),
       postBody: this.getPostBody(),
       postTitle: this.getPostTitle(),
       headerEndLine: this.getHeaderEndLine(),

--- a/web-app/test/fixtures/discussion_posts/with-labels-array.md
+++ b/web-app/test/fixtures/discussion_posts/with-labels-array.md
@@ -1,0 +1,13 @@
+<!--
+author: philip-gai
+repository: https://github.com/philip-gai/announcement-drafter
+category: announcements
+labels:
+  - enhancement
+  - documentation
+  - bug
+-->
+
+# Discussion With Labels Array
+
+Testing that posting with labels in YAML array format works correctly!

--- a/web-app/test/fixtures/discussion_posts/with-labels.md
+++ b/web-app/test/fixtures/discussion_posts/with-labels.md
@@ -1,0 +1,10 @@
+<!--
+author: philip-gai
+repository: https://github.com/philip-gai/announcement-drafter
+category: announcements
+labels: enhancement, documentation
+-->
+
+# Discussion With Labels
+
+Testing that posting with labels works correctly! This discussion should have the "enhancement" and "documentation" labels applied.


### PR DESCRIPTION
## Summary
Add support for specifying labels in the YAML header of discussion posts. Labels will be automatically applied to the created discussion when the PR is merged.

## Changes
- **parserService.ts**: Add `labels` field to `ParsedMarkdownDiscussion` interface and `getLabels()` method that supports both comma-separated strings and YAML arrays
- **githubService.ts**: Add `getRepoLabels()` GraphQL query and `addLabelsToDiscussion()` mutation using `addLabelsToLabelable`
- **pullRequestEventHandler.ts**: Add `resolveLabelIds()` helper and integrate label addition after discussion creation
- **README.md**: Document the new `labels` field with examples
- **Test fixtures**: Add `with-labels.md` and `with-labels-array.md` test files

## Usage
```yaml
<!--
author: username
repository: https://github.com/owner/repo
category: announcements
labels: enhancement, documentation
-->
```

Or using YAML array syntax:
```yaml
<!--
author: username
repository: https://github.com/owner/repo
category: announcements
labels:
  - enhancement
  - documentation
-->
```

Labels that don't exist in the target repository are silently ignored.

Closes #101