### PR TITLE
fix: set WEBHOOK_PATH=/ for Probot v13 compatibility

### DIFF
--- a/infrastructure/modules/appservice-module.bicep
+++ b/infrastructure/modules/appservice-module.bicep
@@ -43,6 +43,10 @@ var finalAppSettings = concat(appSettings, [
     value: 'true'
   }
   {
+    name: 'WEBHOOK_PATH'
+    value: '/'
+  }
+  {
     name: 'WEBHOOK_PROXY_URL'
     value: 'https://${siteUrl}'
   }


### PR DESCRIPTION
## Problem

All incoming GitHub webhook deliveries have been returning **404** since the Probot v12 → v13 upgrade deployed on January 22, 2026 (commit 0bf42da in PR #107).

Probot v13 changed the default webhook listener path from `/` to `/api/github/webhooks`. Since the GitHub App is configured to deliver webhooks to `https://announcement-drafter.azurewebsites.net/` (root path), every `POST /` from GitHub gets a 404 while custom routes like `GET /health` still return 200.

## Evidence

- Azure App Service logs show every `POST /` from `GitHub-Hookshot/*` returning 404
- `GET /health` continues to return 200 (this route is registered on the Express router directly)
- The 404s have been continuous since at least Feb 3 (earliest logs available), all after the Jan 22 deployment

## Fix

Adds `WEBHOOK_PATH=/` to the App Service settings in the Bicep infrastructure template. This tells Probot v13 to listen for webhooks at `/` instead of the new default `/api/github/webhooks`, restoring compatibility with the existing GitHub App webhook URL configuration.

## Alternative considered

Updating the GitHub App's webhook URL to `https://announcement-drafter.azurewebsites.net/api/github/webhooks` — but setting the env var is less disruptive and keeps the configuration in the infrastructure-as-code.